### PR TITLE
Prevent Chromium Crash Dialogs in Kiosk Mode

### DIFF
--- a/kiosk.sh
+++ b/kiosk.sh
@@ -13,4 +13,4 @@ echo 'Hiding the mouse cursor...'
 unclutter -idle 0.1 -root &
 
 echo 'Starting Chromium...'
-/usr/bin/chromium-browser --noerrdialogs --disable-infobars --kiosk --app=$KIOSK_URL
+/usr/bin/chromium-browser --noerrdialogs --disable-session-crashed-bubble --disable-restore-session-state --disable-infobars --kiosk --app=$KIOSK_URL


### PR DESCRIPTION
Added arguments to suppress Chromium crash recovery dialogs:

--disable-session-crashed-bubble - Disables the "Chromium didn't shut down correctly" dialog.
--disable-restore-session-state - Prevents Chromium from attempting to restore the previous session.
