### PR TITLE
Change chromium-browser to chromium in kiosk.sh

### DIFF
--- a/kiosk.sh
+++ b/kiosk.sh
@@ -13,4 +13,4 @@ echo 'Hiding the mouse cursor...'
 unclutter -idle 0.1 -root &
 
 echo 'Starting Chromium...'
-/usr/bin/chromium-browser --noerrdialogs --disable-infobars --kiosk --app=$KIOSK_URL
+/usr/bin/chromium --noerrdialogs --disable-infobars --kiosk --app=$KIOSK_URL


### PR DESCRIPTION
I recently tried to start the kiosk in Trixie OS version on RPi 5 and needed to change the browser name in the script. The default installed browser is "chromium", not "chromium-browser"