### PR TITLE
Fix username placeholder expected by sed command

### DIFF
--- a/kiosk.service
+++ b/kiosk.service
@@ -6,7 +6,7 @@ After=graphical.target
 [Service]
 Environment="DISPLAY=:0"
 Type=simple
-ExecStart=/bin/bash /home/pi/kiosk/kiosk.sh
+ExecStart=/bin/bash /home/USER_HERE/kiosk/kiosk.sh
 Restart=on-abort
 User=USER_HERE
 Group=USER_HERE


### PR DESCRIPTION
The `kiosk.service` file uses `pi` as a username placeholder; however, the sed command in the `README.md` expects `USER_HERE`.

I have updated the `kiosk.service` file to use `USER_HERE` as the placeholder so that the sed replaces the username correctly, allowing the service to run.